### PR TITLE
Reuse the address on not-Windows systems

### DIFF
--- a/networking/src/lib.rs
+++ b/networking/src/lib.rs
@@ -441,6 +441,17 @@ impl Server {
         }
     }
 
+    #[cfg(windows)]
+    fn reuse_address(&self, builder: &TcpBuilder) -> io::Result<()> {
+        Ok(())
+    }
+
+    #[cfg(not(windows))]
+    fn reuse_address(&self, builder: &TcpBuilder) -> io::Result<()> {
+        try!(builder.reuse_address(true));
+        Ok(())
+    }
+
     /// Join the listener threads.
     pub fn join(&mut self) {
         #![allow(unused_must_use)]
@@ -457,6 +468,8 @@ impl Server {
                 SocketAddr::V4(_) => TcpBuilder::new_v4(),
                 SocketAddr::V6(_) => TcpBuilder::new_v6(),
             });
+
+            try!(self.reuse_address(&builder));
             let listener = try!(try!(
                         builder.bind(addr))
                     .listen(tcp_backlog));


### PR DESCRIPTION
Once https://github.com/alexcrichton/net2-rs/pull/6 is merged, this will enable the same behaviour as `real` Redis.

I explicitely disabled it for Windows for the known and discussed reasons.