### PR TITLE
Replaced obsolete kernel32-sys crate with winapi crate

### DIFF
--- a/compat/Cargo.toml
+++ b/compat/Cargo.toml
@@ -10,4 +10,4 @@ libc ="0.1.8"
 libc ="0.1.8"
 
 [dependencies]
-kernel32-sys = "0.1.2"
+winapi = "0.3"

--- a/compat/src/lib.rs
+++ b/compat/src/lib.rs
@@ -8,7 +8,7 @@ pub mod utsname;
 pub use unix::*;
 
 #[cfg(windows)]
-extern crate kernel32;
+extern crate winapi;
 #[cfg(windows)]
 pub mod win;
 #[cfg(windows)]

--- a/compat/src/win.rs
+++ b/compat/src/win.rs
@@ -1,4 +1,4 @@
-use kernel32::GetCurrentProcessId;
+use winapi::um::processthreadsapi::GetCurrentProcessId;
 
 pub fn getpid() -> u32 {
     unsafe { GetCurrentProcessId() as u32 }


### PR DESCRIPTION
Fix for issue #15 (rsedis not compiling on windows). Now I can compile it for x86_64-pc-windows-msvc on Windows 8.1 with Visual Studio 2019