### PR TITLE
Remove time v0.1

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -10,5 +10,5 @@ path = "../logger"
 path = "../util"
 
 [dependencies]
-time = "0.1"
+time = "0.3"
 rand = "0.3"

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Sebastian Waisbrot <seppo0010@gmail.com>"]
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-syslog = "2.2.0"
+syslog = "6.1"
 
 [target.x86_64-apple-darwin.dependencies]
-syslog = "2.2.0"
+syslog = "6.1"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 authors = ["Sebastian Waisbrot <seppo0010@gmail.com>"]
 
 [dependencies]
-time = "0.1"
+time = "0.3"
 libc = "0.1.8"
-rand = "0.3"
+rand = "0.8.5"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -2,6 +2,7 @@
 name = "util"
 version = "0.1.0"
 authors = ["Sebastian Waisbrot <seppo0010@gmail.com>"]
+edition = "2021"
 
 [dependencies]
 time = "0.3"

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -5,8 +5,9 @@ extern crate time;
 use std::fmt;
 
 use libc::types::os::arch::c95::c_int;
-use rand::{thread_rng, Rng};
-use time::get_time;
+use rand::{thread_rng, RngCore};
+use time::OffsetDateTime;
+
 
 /// Are two chars the same? Optionally ignoring the case.
 ///
@@ -163,8 +164,8 @@ pub fn glob_match(pattern: &[u8], element: &[u8], ignore_case: bool) -> bool {
 
 /// Current timestamp in microseconds
 pub fn ustime() -> i64 {
-    let tv = get_time();
-    tv.sec * 1000000 + (tv.nsec / 1000) as i64
+    let now = OffsetDateTime::now_utc();
+    (now.unix_timestamp_nanos() / 1_000).try_into().unwrap()
 }
 
 /// Current timestamp in milliseconds


### PR DESCRIPTION
time v0.1 has a CVE https://osv.dev/vulnerability/RUSTSEC-2020-0071

This upgrades time and syslog, which depended on time v0.1